### PR TITLE
Add original author and license.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,4 @@
 MRuby::Gem::Specification.new('mruby-msgpack') do |spec|
-  spec.license = 'MIT'
-  spec.author  = 'Jun Hiroe'
+  spec.licenses = ['MIT', 'Apache2.0']
+  spec.authors  = ['Jun Hiroe', 'FURUHASHI Sadayuki']
 end


### PR DESCRIPTION
At least today's main branch, it looks almost all code is based on msgpack-ruby.
So I think it's better to add the original author.
