### PR TITLE
Add str 8 type to unpacker

### DIFF
--- a/src/unpacker.c
+++ b/src/unpacker.c
@@ -438,7 +438,18 @@ read_primitive(mrb_state *mrb, msgpack_unpacker_t* uk)
     //case 0xd6:  /* big integer 16 */
     //case 0xd7:  /* big integer 32 */
     //case 0xd8:  /* big float 16 */
-    //case 0xd9:  /* big float 32 */
+
+    case 0xd9:  /* raw 8 */
+      {
+        READ_CAST_BLOCK_OR_RETURN_EOF(mrb, cb, uk, 1);
+        uint8_t count = cb->u8;
+        if (count == 0) {
+            return object_complete_string(uk, mrb_str_buf_new(mrb, 0));
+        }
+        /* read_raw_body_begin sets uk->reading_raw */
+        uk->reading_raw_remaining = count;
+        return read_raw_body_begin(mrb, uk);
+      }
 
     case 0xda:  /* raw 16 */
       {

--- a/test/unpacker_test.rb
+++ b/test/unpacker_test.rb
@@ -214,5 +214,15 @@ assert('MessagePack.unpack', 'FixMap {"a" => 1}') do
   assert_equal({"a" => 1}, msg)
 end
 
+assert('MessagePack.unpack', 'str8 "a" * 32') do
+  msg = MessagePack.unpack("\xd9\x20" + "\x61" * 32)
+  assert_equal("a" * 32, msg)
+end
+
+assert('MessagePack.unpack', 'str8 "a" * 255') do
+  msg = MessagePack.unpack("\xd9\xff" + "\x61" * 255)
+  assert_equal("a" * 255, msg)
+end
+
 # End -- MessagePack-mruby --
 


### PR DESCRIPTION
In msgpack spec https://github.com/msgpack/msgpack/blob/master/spec.md ,
0xd9 is defined str 8.

Signed-off-by: Go Saito gos@iij.ad.jp
